### PR TITLE
更新子项目ureport2-console中的依赖

### DIFF
--- a/ureport2-console/pom.xml
+++ b/ureport2-console/pom.xml
@@ -15,12 +15,12 @@
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.3.2</version>
+            <version>1.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.velocity</groupId>
-            <artifactId>velocity</artifactId>
-            <version>1.7</version>
+            <artifactId>velocity-engine-core</artifactId>
+            <version>2.3</version>
         </dependency>
         <dependency>
             <groupId>com.bstek.ureport</groupId>


### PR DESCRIPTION
在使用您的项目时，我们通过安全扫描工具发现您的子项目ureport2-console中存在安全漏洞，由该子项目中使用到的commons-fileupload.1.3.2和velocity-1.7引入。
在本次PR中，我们将上述的两个依赖更新为其各自的最新版本，以求规避安全漏洞。